### PR TITLE
Add registration prompt on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Start the bot with:
 python bot.py
 ```
 
-The bot currently supports `/start` and `/help` commands and can be extended by adding more handlers in `bot.py`.
+The bot currently supports `/start` and `/help`. When `/start` is issued by the allowed user the bot asks whether to begin the Serbian course. Selecting **Да** saves the user's public information in the database together with the registration timestamp, while **Нет** ends the conversation. Additional handlers can be added in `bot.py`.
 
 ## Docker
 

--- a/db_init/init.sql
+++ b/db_init/init.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,
     telegram_id BIGINT UNIQUE NOT NULL,
-    username TEXT NOT NULL
+    username TEXT NOT NULL,
+    registered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- ask new users if they want to start learning Serbian
- save accepted users with timestamp in database

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685bfca012008324b7fbe861ad674006