### PR TITLE
Implement sentence translation activity

### DIFF
--- a/db_init/init.sql
+++ b/db_init/init.sql
@@ -4,3 +4,36 @@ CREATE TABLE IF NOT EXISTS users (
     username TEXT NOT NULL,
     registered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Vocabulary learning tables
+
+CREATE TABLE IF NOT EXISTS topics (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS phrases (
+    id SERIAL PRIMARY KEY,
+    original TEXT NOT NULL,
+    translation TEXT NOT NULL,
+    difficulty INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS phrase_topics (
+    phrase_id INTEGER NOT NULL REFERENCES phrases(id) ON DELETE CASCADE,
+    topic_id INTEGER NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
+    PRIMARY KEY (phrase_id, topic_id)
+);
+
+CREATE VIEW IF NOT EXISTS phrase_view AS
+SELECT id, original, translation, difficulty
+FROM phrases
+ORDER BY difficulty ASC;
+
+CREATE TABLE IF NOT EXISTS progress (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    phrase_id INTEGER NOT NULL REFERENCES phrases(id) ON DELETE CASCADE,
+    answered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    correct BOOLEAN NOT NULL
+);


### PR DESCRIPTION
## Summary
- expand database schema with topics, phrases and progress tracking
- create phrase view ordered by difficulty
- add translation functionality to the bot
- store user progress and provide next phrase sequentially

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685c018c99948324bf60fd5b2cdb77bf